### PR TITLE
Update the route so that it doesn't default to the blacklight module 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: ruby
+rvm: 2.5

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,18 @@ require File.expand_path('../config/application', __FILE__)
 Rails.application.load_tasks
 
 require 'solr_wrapper/rake_task' unless Rails.env.production?
+
+desc 'Run Continuous Integration test'
+task :ci do
+  puts "Starting solr"
+  SolrWrapper.wrap(port: '8983') do |solr|
+    solr.with_collection(name: 'blacklight-core',
+                         verbose: true,
+                         managed: true,
+                         dir: File.join(__dir__, 'solr', 'conf')) do
+      Rake::Task['test'].invoke
+    end
+  end
+end
+
+task default: :ci

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
 
     devise_for :users
   end
-  Blacklight::Engine.routes.default_scope = { path: '(:locale)', module: 'blacklight' }
+  Blacklight::Engine.routes.default_scope = { path: '(:locale)' }
   mount Blacklight::Engine, at: '/'
 
   get '/' => 'catalog#index'

--- a/test/integration/bookmarks_test.rb
+++ b/test/integration/bookmarks_test.rb
@@ -3,6 +3,6 @@ require 'test_helper'
 class BookmarksTest < ActionDispatch::IntegrationTest
   test "can see my bookmarks" do
     get "/bookmarks"
-    assert_select "h1", "Bookmarks"
+    assert_select "h2", "Bookmarks"
   end
 end

--- a/test/integration/search_history_test.rb
+++ b/test/integration/search_history_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class SearchHistoryTest < ActionDispatch::IntegrationTest
+  test "can see my search history" do
+    get "/search_history"
+    assert_select "h2", "Search History"
+  end
+end


### PR DESCRIPTION
Because `SearchHistoryController` is in blacklight, but
`Blacklight::SearchHistoryController` is not