### PR TITLE
Fix the route to the search history controller

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
 
     devise_for :users
   end
-  Blacklight::Engine.routes.default_scope = { path: '(:locale)', module: 'blacklight' }
+  Blacklight::Engine.routes.default_scope = { path: '(:locale)' }
   mount Blacklight::Engine, at: '/'
 
   get '/' => 'catalog#index'


### PR DESCRIPTION
Prior to this change it was routing to
`Blacklight::SearchHistoryController`, but now it's routing to
`::SearchHistoryController`