### PR TITLE
Revert "Bump puma from 6.1.1 to 6.3.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
     ostruct (0.5.5)
     popper_js (2.11.6)
     public_suffix (5.0.1)
-    puma (6.3.1)
+    puma (6.1.1)
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.6.4)


### PR DESCRIPTION
Can we try reverting this change to see if it fixes the demo app?