### PR TITLE
Change dependabot versioning-strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       dependencies:
         patterns:
           - "*"
-    versioning-strategy: increase-if-necessary      
+    versioning-strategy: lockfile-only      
     schedule:
       interval: "weekly"
       time: "04:00"


### PR DESCRIPTION
We don't want it to upgrade major version in the Gemfile.  It has recently tried to do this with sqlite3, (up to version 2.0.2, which is incompatible with Rails)

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy