### PR TITLE
Pin solr version to 9.6

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -3,3 +3,4 @@
 collection:
   dir: solr/conf/
   name: blacklight-core
+version: 9.6.1


### PR DESCRIPTION
Solr introduced a backwards incompatability in the config in 9.7